### PR TITLE
Add Laravel 12 and 13 compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,21 +14,34 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 5
+    timeout-minutes: 15
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.2]
-        laravel: [11.*, 10.*]
+        php: [8.4, 8.3, 8.2]
+        laravel: [13.*, 12.*, 11.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.0
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: ^3.0
           - laravel: 11.*
             testbench: 9.*
             carbon: ^2.63
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
+        exclude:
+          - php: 8.2
+            laravel: 11.*
+          - php: 8.2
+            laravel: 12.*
+          - php: 8.2
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -50,7 +63,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0|^11.0",
-        "laravel/framework": "^10.0|^11.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
         "laravel/prompts": "^0.1.25",
         "league/oauth2-client": "^2.7",
         "spatie/laravel-package-tools": "^1.16"
@@ -35,7 +35,7 @@
         "laravel/pint": "^1.14",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "^9.4",
+        "orchestra/testbench": "^9.4|^10.0|^11.0",
         "pestphp/pest": "^2.34",
         "pestphp/pest-plugin-arch": "^2.7",
         "pestphp/pest-plugin-laravel": "^2.3",


### PR DESCRIPTION
Extends framework version constraints to support Laravel 12 and 13 alongside existing Laravel 10/11 support.

- `illuminate/contracts` and `laravel/framework`: added `^12.0|^13.0`
- `orchestra/testbench`: added `^10.0|^11.0` to cover the new Laravel versions
