### PR TITLE
Add Dependabot config for Composer and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Dependencias de Composer (PHP)
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  # GitHub Actions usadas en los workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
Añade `.github/dependabot.yml` con actualizaciones semanales para dependencias de Composer (PHP) y GitHub Actions.

Dependabot solo lee la configuración desde la rama por defecto, por lo que necesita estar en `main` para activarse.

Changelog: added