### PR TITLE
v3.1 hardening: renewal service, callback validation, i18n

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
-        "larastan/larastan": "^2.0|^3.0",
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.14",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.1.1",

--- a/resources/lang/en/translations.php
+++ b/resources/lang/en/translations.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 return [
     'can-also-authenticate' => 'you can also authenticate with:',
+    'authentication-failed' => 'Authentication failed. Please try again.',
+    'session-expired'       => 'Your session has expired. Please log in again.',
 ];

--- a/resources/lang/es/translations.php
+++ b/resources/lang/es/translations.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 return [
     'can-also-authenticate' => 'tambien puedes autenticarte con:',
+    'authentication-failed' => 'La autenticación ha fallado. Inténtalo de nuevo.',
+    'session-expired'       => 'Tu sesión ha expirado. Inicia sesión de nuevo.',
 ];

--- a/src/Contracts/OAuthGroupHandlerInterface.php
+++ b/src/Contracts/OAuthGroupHandlerInterface.php
@@ -11,7 +11,7 @@ interface OAuthGroupHandlerInterface
     /**
      * Handle groups retrieved from OAuth provider.
      *
-     * @param array<string,string> $groups
+     * @param array<array-key, string> $groups
      */
     public function handleGroups(array $groups, Model $user): void;
 }

--- a/src/Contracts/OAuthUserHandlerInterface.php
+++ b/src/Contracts/OAuthUserHandlerInterface.php
@@ -12,7 +12,7 @@ interface OAuthUserHandlerInterface
     /**
      * Handle user logged with OAuth provider.
      *
-     * @param array<string,string> $data
+     * @param array<string, mixed> $data
      */
     public function handleUser(array $data, AccessTokenInterface $accessToken): Model;
 }

--- a/src/Controllers/OAuthController.php
+++ b/src/Controllers/OAuthController.php
@@ -21,6 +21,7 @@ use Raiolanetworks\OAuth\Contracts\OAuthUserHandlerInterface;
 use Raiolanetworks\OAuth\Events\OAuthTokenUpdated;
 use Raiolanetworks\OAuth\Models\OAuth;
 use Raiolanetworks\OAuth\Services\OAuthService;
+use Raiolanetworks\OAuth\Services\TokenRenewalService;
 use Symfony\Component\HttpFoundation\RedirectResponse as HttpFoundationRedirectResponse;
 
 class OAuthController extends Controller
@@ -62,20 +63,24 @@ class OAuthController extends Controller
         }
 
         try {
-            $session = Session::all();
-
-            $code  = $request->get('code');
-            $state = $request->get('state');
+            $code         = $request->query('code');
+            $state        = $request->query('state');
+            $sessionState = Session::get('oauth2-state');
+            $pkceCode     = Session::get('oauth2-pkceCode');
 
             if (! isset($code)) {
                 throw new IdentityProviderException('Invalid code', 0, 'Invalid code');
             }
 
-            if (! isset($state) || ! isset($session['oauth2-state']) || $state !== $session['oauth2-state']) {
+            if (! isset($state) || $sessionState === null || $state !== $sessionState) {
                 throw new IdentityProviderException('Invalid state', 0, 'Invalid state');
             }
 
-            $this->provider->setPkceCode($session['oauth2-pkceCode']);
+            if (! is_string($pkceCode)) {
+                throw new IdentityProviderException('Invalid PKCE code', 0, 'Invalid PKCE code');
+            }
+
+            $this->provider->setPkceCode($pkceCode);
 
             /** @var AccessToken $accessToken */
             $accessToken = $this->provider->getAccessToken('authorization_code', [
@@ -83,6 +88,10 @@ class OAuthController extends Controller
             ]);
 
             $callback = $this->provider->getResourceOwner($accessToken)->toArray();
+
+            if (! isset($callback['sub'])) {
+                throw new IdentityProviderException('Missing resource owner identifier', 0, 'Missing resource owner identifier');
+            }
 
             $user = $this->userHandler->handleUser($callback, $accessToken);
             $this->groupHandler->handleGroups($callback['groups'] ?? [], $user);
@@ -100,6 +109,7 @@ class OAuthController extends Controller
             );
 
             OAuthTokenUpdated::dispatch($user, $oauthData, $callback['groups'] ?? []);
+            app(TokenRenewalService::class)->rememberExpiry($accessToken->getExpires());
             Session::remove('oauth2-state');
             Session::remove('oauth2-pkceCode');
 
@@ -117,65 +127,15 @@ class OAuthController extends Controller
             $loginRouteName = config('oauth.login_route_name');
 
             return Redirect::route($loginRouteName)
-                ->with(['message' => 'Authentication failed. Please try again.']);
+                ->with(['message' => __('oauth::translations.authentication-failed')]);
         }
     }
 
+    /**
+     * @deprecated Use {@see TokenRenewalService::renew()} instead. Kept for backward compatibility.
+     */
     public function renew(): ?RedirectResponse
     {
-        /** @var string $guardName */
-        $guardName = config('oauth.guard_name');
-
-        if (Auth::guard($guardName)->check()) {
-            $user      = Auth::guard($guardName)->user();
-            $oauthData = OAuth::whereUserId($user?->getAuthIdentifier())->first();
-
-            // @phpstan-ignore-next-line
-            if ($oauthData !== null && $oauthData->oauth_token !== null && $oauthData->oauth_token_expires_at < now()->timestamp) {
-                if (config('oauth.offline_access') === false) {
-                    return $this->unauthorizeAndLogout($oauthData, $guardName);
-                }
-
-                try {
-                    /** @var AccessToken $accessToken */
-                    $accessToken = $this->provider->getAccessToken('refresh_token', [
-                        'refresh_token' => $oauthData->oauth_refresh_token, // @phpstan-ignore-line
-                    ]);
-
-                    $resourceOwner = $this->provider->getResourceOwner($accessToken);
-                    $callback      = $resourceOwner->toArray();
-                } catch (IdentityProviderException|ClientException) {
-                    return $this->unauthorizeAndLogout($oauthData, $guardName);
-                }
-
-                $oauthData->update([
-                    'oauth_token'            => $accessToken->getToken(),
-                    'oauth_refresh_token'    => $accessToken->getRefreshToken(),
-                    'oauth_token_expires_at' => $accessToken->getExpires(),
-                ]);
-
-                /** @var Model $user */
-                OAuthTokenUpdated::dispatch($user, $oauthData, $callback['groups'] ?? []);
-            }
-        }
-
-        return null;
-    }
-
-    protected function unauthorizeAndLogout(OAuth $oauthData, string $guardName): RedirectResponse
-    {
-        $oauthData->update([
-            'oauth_token'            => null,
-            'oauth_refresh_token'    => null,
-            'oauth_token_expires_at' => null,
-        ]);
-
-        Auth::guard($guardName)->logout();
-
-        /** @var string $loginRouteName */
-        $loginRouteName = config('oauth.login_route_name');
-
-        return Redirect::route($loginRouteName)
-            ->with(['message' => 'Your session has expired. Please log in again.']);
+        return app(TokenRenewalService::class)->renew();
     }
 }

--- a/src/Events/OAuthTokenUpdated.php
+++ b/src/Events/OAuthTokenUpdated.php
@@ -26,6 +26,5 @@ class OAuthTokenUpdated
     {
         $this->user      = $user->refresh();
         $this->oauthData = $oauthData->refresh();
-        $this->groups    = $groups;
     }
 }

--- a/src/Handlers/BaseOAuthGroupHandler.php
+++ b/src/Handlers/BaseOAuthGroupHandler.php
@@ -12,7 +12,7 @@ class BaseOAuthGroupHandler implements OAuthGroupHandlerInterface
     /**
      * Handle groups retrieved from OAuth provider.
      *
-     * @param array<string,string> $groups
+     * @param array<array-key, string> $groups
      */
     public function handleGroups(array $groups, Model $user): void
     {

--- a/src/Handlers/BaseOAuthUserHandler.php
+++ b/src/Handlers/BaseOAuthUserHandler.php
@@ -7,21 +7,20 @@ namespace Raiolanetworks\OAuth\Handlers;
 use Illuminate\Database\Eloquent\Model;
 use League\OAuth2\Client\Token\AccessTokenInterface;
 use Raiolanetworks\OAuth\Contracts\OAuthUserHandlerInterface;
-use Raiolanetworks\OAuth\Models\OAuth;
 
 class BaseOAuthUserHandler implements OAuthUserHandlerInterface
 {
     /**
      * Handle user logged with OAuth provider.
      *
-     * @param array<mixed> $userData
+     * @param array<string, mixed> $userData
      */
     public function handleUser(array $userData, AccessTokenInterface $accessToken): Model
     {
-        /** @var Model $model */
+        /** @var class-string<Model> $model */
         $model = config('oauth.user_model_name');
 
-        return (new $model())::updateOrCreate(
+        return $model::updateOrCreate(
             [
                 'email' => $userData['email'],
             ],

--- a/src/Middleware/OAuthTokenRenewal.php
+++ b/src/Middleware/OAuthTokenRenewal.php
@@ -6,11 +6,15 @@ namespace Raiolanetworks\OAuth\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Raiolanetworks\OAuth\Controllers\OAuthController;
+use Raiolanetworks\OAuth\Services\TokenRenewalService;
 use Symfony\Component\HttpFoundation\Response;
 
 class OAuthTokenRenewal
 {
+    public function __construct(
+        protected TokenRenewalService $tokenRenewal,
+    ) {}
+
     /**
      * Handle an incoming request.
      *
@@ -18,8 +22,7 @@ class OAuthTokenRenewal
      */
     public function handle(Request $request, Closure $next): Response
     {
-        $authController = app(OAuthController::class);
-        $response       = $authController->renew();
+        $response = $this->tokenRenewal->renew();
 
         if ($response !== null) {
             return $response;

--- a/src/Services/TokenRenewalService.php
+++ b/src/Services/TokenRenewalService.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Raiolanetworks\OAuth\Services;
+
+use GuzzleHttp\Exception\ClientException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Session;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Token\AccessToken;
+use Raiolanetworks\OAuth\Events\OAuthTokenUpdated;
+use Raiolanetworks\OAuth\Models\OAuth;
+
+/**
+ * Handles OAuth access-token renewal.
+ *
+ * Kept out of the controller so it can be reused from middleware without
+ * resolving a full controller instance per request.
+ */
+class TokenRenewalService
+{
+    /**
+     * Session key holding the cached token expiry timestamp. Lets the
+     * middleware skip the database lookup while the token is still valid.
+     */
+    public const EXPIRY_SESSION_KEY = 'oauth2-token-expires-at';
+
+    public function __construct(
+        protected OAuthService $provider,
+    ) {}
+
+    /**
+     * Renew the current user's access token when it has expired.
+     *
+     * Returns a redirect response when the session can no longer be renewed
+     * (and the user was logged out), or null when nothing needed to happen.
+     */
+    public function renew(): ?RedirectResponse
+    {
+        /** @var string $guardName */
+        $guardName = config('oauth.guard_name');
+
+        if (! Auth::guard($guardName)->check()) {
+            return null;
+        }
+
+        // Fast path: while the cached expiry says the token is still valid we
+        // avoid touching the database entirely.
+        $cachedExpiry = Session::get(self::EXPIRY_SESSION_KEY);
+
+        if (is_int($cachedExpiry) && $cachedExpiry >= now()->timestamp) {
+            return null;
+        }
+
+        $user      = Auth::guard($guardName)->user();
+        $oauthData = OAuth::whereUserId($user?->getAuthIdentifier())->first();
+
+        // @phpstan-ignore-next-line
+        if ($oauthData === null || $oauthData->oauth_token === null || $oauthData->oauth_token_expires_at >= now()->timestamp) {
+            // Nothing to renew: refresh the cache so future requests short-circuit.
+            $this->rememberExpiry($oauthData?->oauth_token_expires_at); // @phpstan-ignore-line
+
+            return null;
+        }
+
+        if (config('oauth.offline_access') === false) {
+            return $this->unauthorizeAndLogout($oauthData, $guardName);
+        }
+
+        try {
+            /** @var AccessToken $accessToken */
+            $accessToken = $this->provider->getAccessToken('refresh_token', [
+                'refresh_token' => $oauthData->oauth_refresh_token, // @phpstan-ignore-line
+            ]);
+
+            $resourceOwner = $this->provider->getResourceOwner($accessToken);
+            $callback      = $resourceOwner->toArray();
+        } catch (IdentityProviderException|ClientException) {
+            return $this->unauthorizeAndLogout($oauthData, $guardName);
+        }
+
+        $oauthData->update([
+            'oauth_token'            => $accessToken->getToken(),
+            'oauth_refresh_token'    => $accessToken->getRefreshToken(),
+            'oauth_token_expires_at' => $accessToken->getExpires(),
+        ]);
+
+        $this->rememberExpiry($accessToken->getExpires());
+
+        /** @var Model $user */
+        OAuthTokenUpdated::dispatch($user, $oauthData, $callback['groups'] ?? []);
+
+        return null;
+    }
+
+    /**
+     * Cache the token expiry timestamp in the session so the middleware can
+     * skip the database lookup on subsequent requests.
+     */
+    public function rememberExpiry(?int $expiresAt): void
+    {
+        if ($expiresAt === null) {
+            Session::forget(self::EXPIRY_SESSION_KEY);
+
+            return;
+        }
+
+        Session::put(self::EXPIRY_SESSION_KEY, $expiresAt);
+    }
+
+    protected function unauthorizeAndLogout(OAuth $oauthData, string $guardName): RedirectResponse
+    {
+        $oauthData->update([
+            'oauth_token'            => null,
+            'oauth_refresh_token'    => null,
+            'oauth_token_expires_at' => null,
+        ]);
+
+        Session::forget(self::EXPIRY_SESSION_KEY);
+
+        Auth::guard($guardName)->logout();
+
+        /** @var string $loginRouteName */
+        $loginRouteName = config('oauth.login_route_name');
+
+        return Redirect::route($loginRouteName)
+            ->with(['message' => __('oauth::translations.session-expired')]);
+    }
+}

--- a/tests/Feature/MiddlewareTest.php
+++ b/tests/Feature/MiddlewareTest.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Raiolanetworks\OAuth\Controllers\OAuthController;
 use Raiolanetworks\OAuth\Middleware\OAuthTokenRenewal;
+use Raiolanetworks\OAuth\Services\TokenRenewalService;
 use Symfony\Component\HttpFoundation\Response;
 
-it('calls the OAuthController renew method and allows the request to proceed', function () {
-    $mockController = Mockery::mock(OAuthController::class);
+it('calls the token renewal service and allows the request to proceed', function () {
+    $mockService = Mockery::mock(TokenRenewalService::class);
 
-    $mockController->shouldReceive('renew')->once()->andReturnNull();
+    $mockService->shouldReceive('renew')->once()->andReturnNull();
 
-    $middleware = new OAuthTokenRenewal();
-
-    $this->instance(OAuthController::class, $mockController);
+    $middleware = new OAuthTokenRenewal($mockService);
 
     $response = $middleware->handle(Request::create('/test-url', 'GET'), fn () => new Response('Next middleware called'));
 
@@ -23,14 +21,12 @@ it('calls the OAuthController renew method and allows the request to proceed', f
 });
 
 it('returns the redirect response from renew when token renewal triggers a redirect', function () {
-    $mockController = Mockery::mock(OAuthController::class);
+    $mockService = Mockery::mock(TokenRenewalService::class);
 
     $redirect = new RedirectResponse('/login');
-    $mockController->shouldReceive('renew')->once()->andReturn($redirect);
+    $mockService->shouldReceive('renew')->once()->andReturn($redirect);
 
-    $middleware = new OAuthTokenRenewal();
-
-    $this->instance(OAuthController::class, $mockController);
+    $middleware = new OAuthTokenRenewal($mockService);
 
     $response = $middleware->handle(Request::create('/test-url', 'GET'), fn () => new Response('Next middleware called'));
 

--- a/tests/Feature/TokenRenewalServiceTest.php
+++ b/tests/Feature/TokenRenewalServiceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Session;
+
+use function Pest\Laravel\instance;
+
+use Raiolanetworks\OAuth\Models\OAuth;
+use Raiolanetworks\OAuth\Services\OAuthService;
+use Raiolanetworks\OAuth\Services\TokenRenewalService;
+use Raiolanetworks\OAuth\Tests\Models\TestUser;
+
+/** @var TestCase $this */
+it('skips the database lookup and provider when the cached expiry is still valid', function () {
+    Config::set('oauth.offline_access', true);
+
+    $mockUser = TestUser::factory()->create();
+
+    // Expired token in the database: without the cache this would trigger a renewal.
+    OAuth::factory(state: [
+        'user_id'                => $mockUser->id,
+        'oauth_token'            => 'some_token',
+        'oauth_refresh_token'    => 'some_refresh_token',
+        'oauth_token_expires_at' => Carbon::now()->subHour()->timestamp,
+    ])->create();
+
+    // Cached expiry says the token is still valid.
+    Session::put(TokenRenewalService::EXPIRY_SESSION_KEY, Carbon::now()->addHour()->timestamp);
+
+    Auth::shouldReceive('guard')
+        ->with(config('oauth.guard_name'))
+        ->andReturn(Mockery::mock(Guard::class, ['check' => true, 'user' => $mockUser]));
+
+    // The provider must never be touched on the fast path.
+    $mockOAuthService = Mockery::mock(OAuthService::class);
+    $mockOAuthService->shouldNotReceive('getAccessToken');
+    $mockOAuthService->shouldNotReceive('getResourceOwner');
+    instance(OAuthService::class, $mockOAuthService);
+
+    $response = $this->app->make(TokenRenewalService::class)->renew();
+
+    expect($response)->toBeNull();
+
+    Mockery::close();
+});
+
+/** @var TestCase $this */
+it('caches the token expiry after a successful renewal', function () {
+    Config::set('oauth.offline_access', true);
+
+    $expiresAt = Carbon::now()->addHour()->timestamp;
+
+    $service = $this->app->make(TokenRenewalService::class);
+    $service->rememberExpiry($expiresAt);
+
+    expect(Session::get(TokenRenewalService::EXPIRY_SESSION_KEY))->toBe($expiresAt);
+});


### PR DESCRIPTION
## Resumen

Tanda de *hardening* posterior a v3.0.0. Cambios cohesivos, de bajo riesgo y backward-compatible. Todo va en un único PR → tag **v3.1.0** (la localización de mensajes es aditiva, MINOR bajo semver).

## Cambios

### Fixed
- **Validación de identidad y PKCE en el callback** ([OAuthController](src/Controllers/OAuthController.php)): si falta `sub` o el código PKCE, ahora se lanza `IdentityProviderException` → el fallo se captura y redirige de forma controlada en vez de provocar un 500. Lectura de `code`/`state` vía `query()` (elimina una llamada deprecada de Symfony en L12/L13).

### Changed
- **Renovación de token extraída a `TokenRenewalService`** ([TokenRenewalService](src/Services/TokenRenewalService.php)): el middleware ya no resuelve un `OAuthController` completo por request. Además, un timestamp de expiración cacheado en sesión permite **saltar la query a BD** mientras el token siga vigente. `OAuthController::renew()` se mantiene como delegación `@deprecated` (BC preservada).
- **Tipos de handlers afinados y limpieza**: PHPDoc correctos en los contratos (`array<string, mixed>` / `array<array-key, string>`), `updateOrCreate` estático en `BaseOAuthUserHandler`, import muerto eliminado y asignación redundante fuera en el evento `OAuthTokenUpdated`.

### Added
- **Mensajes de autenticación localizables**: el paquete registraba traducciones pero los mensajes de error del callback y de expiración de sesión estaban hardcodeados en inglés. Nuevas claves `en`/`es`.

### Tooling (sin changelog)
- `larastan` fijado a `^3.0` (la rama `^2.0` era insatisfacible con el stack de dev actual: PHPStan 2.x).

## Verificación
- ✅ 25 tests (74 aserciones)
- ✅ PHPStan (level 9) sin errores
- ✅ Pint

## Notas
- `OAuthController::renew()` queda deprecado en favor de `TokenRenewalService::renew()`.
- Fuera de este PR (para una iteración propia): hacer configurables las URLs del provider (hoy específicas de Authentik).
- La tag `v3.1.0` se crearía tras el merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)