### PR TITLE
Document direct v1→v3 upgrade steps and controller injection

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -25,6 +25,14 @@ use Raiolanetworks\OAuth\Events\OAuthTokenUpdated;
 
 No database migration or token re-encryption is required for the v2 → v3 upgrade.
 
+> **Upgrading directly from v1.x?** The two steps above are not enough on their own. You must **also complete every step in the "Upgrading from v1.x to v2.x" section below** — in particular the database migration and token encryption. Skipping the v2 release does **not** skip its schema changes: without them the first login after the upgrade fails with an error such as:
+>
+> ```
+> SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'oauth_refresh_token' at row 1
+> ```
+>
+> This happens because v2 stores tokens encrypted, and encrypted values no longer fit in the original `string(255)` column.
+
 ---
 
 # Upgrading from v1.x to v2.x
@@ -89,6 +97,17 @@ The facade now resolves to `OAuthService` via the `'oauth'` container key.
 
 ## 5. Other breaking changes
 
-- **Constructor signature changed** in `OAuthController`: nullable parameters with service locator fallback have been replaced with required type-hinted dependencies. If you extended this controller, update your constructor.
+- **Constructor signature changed** in `OAuthController`: nullable parameters with service locator fallback have been replaced with required type-hinted dependencies. Resolve the controller through the service container so its dependencies are injected — do **not** instantiate it manually:
+
+  ```php
+  // Before (breaks in v3: "Too few arguments to function ...OAuthController::__construct(), 0 passed")
+  $controller = new OAuthController();
+  $controller->request();
+
+  // After — the container injects the dependencies, and request() returns the redirect, so return it
+  return app(OAuthController::class)->request();
+  ```
+
+  If you extended this controller, update your constructor accordingly.
 - **Rate limiting**: OAuth routes now include `throttle:5,1` middleware. Override the routes if you need a different limit.
 - **Default `user_model_name`**: Config default changed from `Raiolanetworks\OAuth\Tests\Models\TestUser` to `App\Models\User`. This only affects new installations.


### PR DESCRIPTION
## Resumen

Cierra dos huecos del `UPGRADE.md` detectados al migrar un proyecto real (raiola-faq) que saltó de **v1.0.8 directo a v3.1**.

## Cambios

- **Salto directo v1 → v3**: la sección v2→v3 decía "no migration required", cierto solo si ya venías de v2. Se añade un aviso de que un salto directo desde v1 **también** exige los pasos de v1→v2 (publicar migración, `migrate`, `oauth:encrypt-tokens`), con el error literal que aparece si se omiten:
  ```
  SQLSTATE[22001]: ... Data too long for column 'oauth_refresh_token'
  ```
- **Instanciación del controller**: la nota de breaking change ahora incluye el error exacto (`Too few arguments to function ...__construct(), 0 passed`) y la solución — resolver por el contenedor y devolver el redirect:
  ```php
  return app(OAuthController::class)->request();
  ```

## Notas

- Solo documentación, sin cambios de comportamiento → **sin trailer de changelog**.
- No requiere nueva tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)